### PR TITLE
fix: `initialize()` in the docs

### DIFF
--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -14,7 +14,7 @@ class UserModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -100,7 +100,7 @@ class UserModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -23,7 +23,7 @@ class UserModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -56,7 +56,7 @@ class UserModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -89,7 +89,7 @@ class PostModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -181,7 +181,7 @@ class UserModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -231,7 +231,7 @@ class CountryModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -273,7 +273,7 @@ class StudentModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }
@@ -291,7 +291,7 @@ class CourseModel extends Model
 
     // ...
 
-    public function initialize()
+    protected function initialize()
     {
         $this->initRelations();
     }


### PR DESCRIPTION
This PR fixes the docs as the `initialize()` method should be `protected` not `public`.