### PR TITLE
fix: remove unnecessary imports from tests

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Tests;
 
 use CodeIgniter\Entity\Entity;
-use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\Database\Seeds\SeedTests;
-use Tests\Support\Entities\Profile;
 use Tests\Support\Entities\User;
 use Tests\Support\Models\UserModel;
 


### PR DESCRIPTION
**Description**
Optimized the list of IDs for `whereIn()`. Before that, the IDs were repeated: ` [1, 2, 1, 3, 1]`.
Although SQL optimizes this on its own, it looks better on the PHP side.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
