### PR TITLE
fix: Fixed  test of different database

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -213,8 +213,8 @@ final class ModelTest extends CIUnitTestCase
         $userModel->with('profile')->useTransactions()->insert($user);
 
         $this->assertArrayHasKey('database_error', $userModel->errors());
-        $this->assertSame(
-            "Duplicate entry 'Test User 1' for key 'db_users.username'",
+        $this->assertMatchesRegularExpression(
+            "/Duplicate entry 'Test User 1' for key '(db_users.username|username)'/",
             $userModel->errors()['database_error'],
         );
 


### PR DESCRIPTION
**Description**
Fixes #15 
In different environments, the table name may be omitted in errors.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
