### PR TITLE
fix: relations for entities with datamap

### DIFF
--- a/src/Traits/HasRelations.php
+++ b/src/Traits/HasRelations.php
@@ -7,6 +7,7 @@ namespace Michalsn\CodeIgniterNestedModel\Traits;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Entity\Entity;
 use CodeIgniter\Model;
 use LogicException;
 use Michalsn\CodeIgniterNestedModel\Enums\RelationTypes;
@@ -396,7 +397,15 @@ trait HasRelations
             }
         } else {
             foreach ($this->relations as $relationName => $relationObject) {
-                $ids          = array_column($eventData['data'], $relationObject->primaryKey);
+                $ids = array_unique(array_column(
+                    array_map(
+                        static fn ($item) => $item instanceof Entity
+                            ? $item->toRawArray()
+                            : $item,
+                        $eventData['data'],
+                    ),
+                    $relationObject->primaryKey,
+                ));
                 $relationData = $this->getDataForRelationByIds($ids, $relationObject, $relationName);
 
                 foreach ($eventData['data'] as &$data) {

--- a/tests/HasManyTest.php
+++ b/tests/HasManyTest.php
@@ -8,8 +8,10 @@ use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\Database\Seeds\SeedTests;
+use Tests\Support\Entities\Comment;
 use Tests\Support\Entities\Post;
 use Tests\Support\Entities\User;
+use Tests\Support\Models\CommentModel;
 use Tests\Support\Models\PostModel;
 use Tests\Support\Models\UserModel;
 
@@ -138,5 +140,49 @@ final class HasManyTest extends CIUnitTestCase
 
         $this->assertSame('1', $post->user->id);
         $this->assertSame('Test User 1', $post->user->username);
+    }
+
+    public function testFindBelongsToWithEntityDatamap()
+    {
+        // Load normal model
+        $comment = model(CommentModel::class)->find(1);
+        $this->assertInstanceOf(Comment::class, $comment);
+
+        $isset = isset($comment->user);
+        $this->assertFalse($isset);
+
+        // Load model with relation
+        $comment = model(CommentModel::class)->with('user')->find(1);
+        $this->assertInstanceOf(Comment::class, $comment);
+
+        $isset = isset($comment->user);
+        $this->assertTrue($isset);
+
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame('1', $comment->user->id);
+        $this->assertSame('Test User 1', $comment->user->username);
+    }
+
+    public function testFindAllBelongsToWithEntityDatamap()
+    {
+        // Load normal model
+        $comments = model(CommentModel::class)->findAll();
+        $this->assertInstanceOf(Comment::class, $comments[0]);
+
+        $isset = isset($comments[0]->user);
+        $this->assertFalse($isset);
+
+        // Load model with relation
+        $comments = model(CommentModel::class)->with('user')->findAll();
+        $this->assertInstanceOf(Comment::class, $comments[0]);
+
+        $isset = isset($comments[0]->user);
+        $this->assertTrue($isset);
+
+        $this->assertInstanceOf(User::class, $comments[0]->user);
+
+        $this->assertSame('1', $comments[0]->user->id);
+        $this->assertSame('Test User 1', $comments[0]->user->username);
     }
 }

--- a/tests/_support/Entities/Comment.php
+++ b/tests/_support/Entities/Comment.php
@@ -8,7 +8,9 @@ use CodeIgniter\Entity\Entity;
 
 class Comment extends Entity
 {
-    protected $datamap = [];
-    protected $dates   = ['created_at', 'updated_at'];
-    protected $casts   = [];
+    protected $datamap = [
+        'userId' => 'user_id',
+    ];
+    protected $dates = ['created_at', 'updated_at'];
+    protected $casts = [];
 }


### PR DESCRIPTION
**Description**
This PR fixes relations for entities with datamap by ensuring that relationships work correctly when the entity uses datamap to transform property names.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
