### PR TITLE
fix: unnecessary foreign key in `Entity::$original`

### DIFF
--- a/src/Relation.php
+++ b/src/Relation.php
@@ -270,6 +270,10 @@ class Relation
             unset($row[$this->many->pivotForeignKey]);
         } else {
             unset($row->{$this->many->pivotForeignKey});
+
+            if ($row instanceof Entity) {
+                $row->syncOriginal();
+            }
         }
 
         return $row;
@@ -286,6 +290,10 @@ class Relation
                 unset($row[$this->many->pivotForeignKey]);
             } else {
                 unset($row->{$this->many->pivotForeignKey});
+
+                if ($row instanceof Entity) {
+                    $row->syncOriginal();
+                }
             }
         }
 

--- a/tests/ManyTest.php
+++ b/tests/ManyTest.php
@@ -37,6 +37,7 @@ final class ManyTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Course::class, $courses[0]);
         $this->assertSame('Baking for dummies', $courses[0]->name);
+        $this->assertFalse($courses[0]->hasChanged());
     }
 
     public function testFindAllManyCourses()
@@ -51,6 +52,7 @@ final class ManyTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Course::class, $courses[0]);
         $this->assertSame('PHP is not death', $courses[0]->name);
+        $this->assertFalse($courses[0]->hasChanged());
     }
 
     public function testFindManyStudents()
@@ -67,6 +69,7 @@ final class ManyTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Student::class, $students[0]);
         $this->assertSame('Joe', $students[0]->firstname);
+        $this->assertFalse($students[0]->hasChanged());
     }
 
     public function testFindAllManyStudents()
@@ -81,5 +84,6 @@ final class ManyTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Student::class, $students[1]);
         $this->assertSame('Elizabeth', $students[1]->firstname);
+        $this->assertFalse($students[0]->hasChanged());
     }
 }


### PR DESCRIPTION
**Description**
This PR fixes a bug where the entity is not fully synchronized.

Fixes #19

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
