### PR TITLE
feat: bypass `__set()` for loaded relation assignment

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -124,6 +124,12 @@ parameters:
 			message: '#^Call to an undefined method CodeIgniter\\Model\:\:getTable\(\)\.$#'
 			identifier: method.notFound
 			count: 5
+			path: tests/_support/Models/StrictUserModel.php
+
+		-
+			message: '#^Call to an undefined method CodeIgniter\\Model\:\:getTable\(\)\.$#'
+			identifier: method.notFound
+			count: 5
 			path: tests/_support/Models/StudentModel.php
 
 		-

--- a/src/Traits/HasLazyRelations.php
+++ b/src/Traits/HasLazyRelations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Michalsn\CodeIgniterNestedModel\Traits;
 
 use CodeIgniter\Autoloader\FileLocatorInterface;
+use CodeIgniter\Model;
 use Michalsn\CodeIgniterNestedModel\Enums\RelationTypes;
 
 trait HasLazyRelations
@@ -14,15 +15,20 @@ trait HasLazyRelations
      */
     private array $handledRelations = [];
 
+    private ?Model $relationModel       = null;
+    private bool $relationModelResolved = false;
+
     public function __get(string $key)
     {
         if (array_key_exists($key, $this->attributes)) {
             return parent::__get($key);
         }
 
-        if ($this->isRelation($key)) {
+        $model = $this->getRelationModel();
+
+        if ($model !== null && method_exists($model, $key)) {
             if (! isset($this->handledRelations[$key]) && ! array_key_exists($key, $this->attributes)) {
-                $this->handleRelation($key);
+                $this->handleRelation($key, $model);
                 $this->handledRelations[$key] = true;
             }
 
@@ -35,20 +41,8 @@ trait HasLazyRelations
     /**
      * Load relation for the property.
      */
-    private function handleRelation(string $name)
+    private function handleRelation(string $name, Model $model)
     {
-        $className = $this->findModelClass();
-
-        if ($className === null) {
-            return null;
-        }
-
-        $model = model($className);
-
-        if (! method_exists($model, $name)) {
-            return null;
-        }
-
         $relation = $model->{$name}();
 
         if (in_array($relation->type, [RelationTypes::hasOne, RelationTypes::belongsTo], true)) {
@@ -72,17 +66,20 @@ trait HasLazyRelations
     }
 
     /**
-     * Check if the property is a declared relation on the matching model.
+     * Resolve the matching model once for the lifetime of the entity instance.
      */
-    private function isRelation(string $name): bool
+    private function getRelationModel(): ?Model
     {
-        $className = $this->findModelClass();
-
-        if ($className === null) {
-            return false;
+        if ($this->relationModelResolved) {
+            return $this->relationModel;
         }
 
-        return method_exists(model($className), $name);
+        $className = $this->findModelClass();
+
+        $this->relationModel         = $className === null ? null : model($className);
+        $this->relationModelResolved = true;
+
+        return $this->relationModel;
     }
 
     /**

--- a/src/Traits/HasLazyRelations.php
+++ b/src/Traits/HasLazyRelations.php
@@ -16,14 +16,20 @@ trait HasLazyRelations
 
     public function __get(string $key)
     {
-        $result = parent::__get($key);
-
-        if ($result === null && ! isset($this->handledRelations[$key])) {
-            $result                       = $this->handleRelation($key);
-            $this->handledRelations[$key] = true;
+        if (array_key_exists($key, $this->attributes)) {
+            return parent::__get($key);
         }
 
-        return $result;
+        if ($this->isRelation($key)) {
+            if (! isset($this->handledRelations[$key]) && ! array_key_exists($key, $this->attributes)) {
+                $this->handleRelation($key);
+                $this->handledRelations[$key] = true;
+            }
+
+            return $this->attributes[$key] ?? null;
+        }
+
+        return parent::__get($key);
     }
 
     /**
@@ -63,6 +69,20 @@ trait HasLazyRelations
         }
 
         return $this->attributes[$name];
+    }
+
+    /**
+     * Check if the property is a declared relation on the matching model.
+     */
+    private function isRelation(string $name): bool
+    {
+        $className = $this->findModelClass();
+
+        if ($className === null) {
+            return false;
+        }
+
+        return method_exists(model($className), $name);
     }
 
     /**

--- a/src/Traits/HasRelations.php
+++ b/src/Traits/HasRelations.php
@@ -406,7 +406,13 @@ trait HasRelations
                 }
             } else {
                 foreach ($this->relations as $relationName => $relationObject) {
-                    $eventData['data']->{$relationName} = $this->getDataForRelationById($eventData['data']->{$relationObject->primaryKey}, $relationObject, $relationName);
+                    $relationValue = $this->getDataForRelationById($eventData['data']->{$relationObject->primaryKey}, $relationObject, $relationName);
+
+                    if ($eventData['data'] instanceof Entity) {
+                        $this->setEntityRelation($eventData['data'], $relationName, $relationValue);
+                    } else {
+                        $eventData['data']->{$relationName} = $relationValue;
+                    }
                 }
             }
         } else {
@@ -426,7 +432,13 @@ trait HasRelations
                     if ($this->tempReturnType === 'array') {
                         $data[$relationName] = $relationData[$data[$relationObject->primaryKey]] ?? [];
                     } else {
-                        $data->{$relationName} = $relationData[$data->{$relationObject->primaryKey}] ?? [];
+                        $relationValue = $relationData[$data->{$relationObject->primaryKey}] ?? [];
+
+                        if ($data instanceof Entity) {
+                            $this->setEntityRelation($data, $relationName, $relationValue);
+                        } else {
+                            $data->{$relationName} = $relationValue;
+                        }
                     }
                 }
             }
@@ -435,6 +447,19 @@ trait HasRelations
         $this->resetRelations();
 
         return $eventData;
+    }
+
+    /**
+     * Store relation data on an entity without triggering strict __set() implementations.
+     */
+    private function setEntityRelation(Entity $entity, string $relationName, mixed $value): void
+    {
+        $setter = function (string $name, mixed $relationValue): void {
+            // @phpstan-ignore-next-line bound to Entity scope below
+            $this->attributes[$name] = $relationValue;
+        };
+
+        Closure::bind($setter, $entity, Entity::class)($relationName, $value);
     }
 
     /**

--- a/tests/StrictEntityRelationsTest.php
+++ b/tests/StrictEntityRelationsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\Database\Seeds\SeedTests;
+use Tests\Support\Entities\Post;
+use Tests\Support\Entities\Profile;
+use Tests\Support\Entities\StrictUser;
+use Tests\Support\Models\StrictUserModel;
+
+/**
+ * @internal
+ */
+final class StrictEntityRelationsTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $namespace;
+    protected $seed = SeedTests::class;
+
+    public function testEagerLoadsHasOneRelationOnStrictEntity(): void
+    {
+        $user = model(StrictUserModel::class)->with('profile')->find(1);
+
+        $this->assertInstanceOf(StrictUser::class, $user);
+        $this->assertInstanceOf(Profile::class, $user->profile);
+        $this->assertSame('United States', $user->profile->country);
+    }
+
+    public function testEagerLoadsHasManyRelationOnStrictEntity(): void
+    {
+        $user = model(StrictUserModel::class)->with('posts')->find(1);
+
+        $this->assertInstanceOf(StrictUser::class, $user);
+        $this->assertIsArray($user->posts);
+        $this->assertInstanceOf(Post::class, $user->posts[0]);
+        $this->assertSame('Title 1', $user->posts[0]->title);
+    }
+
+    public function testLazyLoadsHasOneRelationOnStrictEntity(): void
+    {
+        $user = model(StrictUserModel::class)->find(1);
+
+        $this->assertInstanceOf(StrictUser::class, $user);
+        $this->assertInstanceOf(Profile::class, $user->profile);
+        $this->assertSame('United States', $user->profile->country);
+    }
+
+    public function testLazyLoadsHasManyRelationOnStrictEntity(): void
+    {
+        $user = model(StrictUserModel::class)->find(1);
+
+        $this->assertInstanceOf(StrictUser::class, $user);
+        $this->assertIsArray($user->posts);
+        $this->assertInstanceOf(Post::class, $user->posts[0]);
+        $this->assertSame('Title 1', $user->posts[0]->title);
+    }
+}

--- a/tests/_support/Entities/StrictEntity.php
+++ b/tests/_support/Entities/StrictEntity.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Entities;
+
+use CodeIgniter\Entity\Entity;
+use LogicException;
+
+abstract class StrictEntity extends Entity
+{
+    protected $dates = [];
+
+    public function __construct(?array $data = null)
+    {
+        parent::__construct(is_array($data) ? $this->filterAttributes($data) : []);
+    }
+
+    public function fill(?array $data = null)
+    {
+        return parent::fill(is_array($data) ? $this->filterAttributes($data) : []);
+    }
+
+    public function injectRawData(array $data)
+    {
+        return parent::injectRawData(array_merge($this->attributes, $this->filterAttributes($data)));
+    }
+
+    public function __set(string $key, $value = null)
+    {
+        $attribute = $this->mapProperty($key);
+
+        if (! array_key_exists($attribute, $this->attributes)) {
+            throw new LogicException(sprintf('Attribute "%s" is not defined.', $attribute));
+        }
+
+        parent::__set($key, $value);
+    }
+
+    public function __get(string $key)
+    {
+        $attribute = $this->mapProperty($key);
+
+        if (! array_key_exists($attribute, $this->attributes)) {
+            throw new LogicException(sprintf('Attribute "%s" is not defined.', $attribute));
+        }
+
+        return parent::__get($key);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    protected function filterAttributes(array $attributes): array
+    {
+        return array_intersect_key($attributes, $this->attributes);
+    }
+}

--- a/tests/_support/Entities/StrictUser.php
+++ b/tests/_support/Entities/StrictUser.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Entities;
+
+use Michalsn\CodeIgniterNestedModel\Traits\HasLazyRelations;
+
+class StrictUser extends StrictEntity
+{
+    use HasLazyRelations;
+
+    protected $attributes = [
+        'id'         => null,
+        'username'   => null,
+        'company_id' => null,
+        'country_id' => null,
+        'created_at' => null,
+        'updated_at' => null,
+    ];
+    protected $datamap = [];
+    protected $dates   = ['created_at', 'updated_at'];
+    protected $casts   = [];
+}

--- a/tests/_support/Models/StrictUserModel.php
+++ b/tests/_support/Models/StrictUserModel.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Models;
+
+use CodeIgniter\Model;
+use Michalsn\CodeIgniterNestedModel\Relation;
+use Michalsn\CodeIgniterNestedModel\Traits\HasRelations;
+use Tests\Support\Entities\StrictUser;
+
+class StrictUserModel extends Model
+{
+    use HasRelations;
+
+    protected $table                  = 'users';
+    protected $primaryKey             = 'id';
+    protected $useAutoIncrement       = true;
+    protected $returnType             = StrictUser::class;
+    protected $useSoftDeletes         = false;
+    protected $protectFields          = true;
+    protected $allowedFields          = ['username', 'company_id', 'country_id'];
+    protected bool $allowEmptyInserts = false;
+    protected bool $updateOnlyChanged = true;
+    protected array $casts            = [];
+    protected array $castHandlers     = [];
+
+    // Dates
+    protected $useTimestamps = true;
+    protected $dateFormat    = 'datetime';
+    protected $createdField  = 'created_at';
+    protected $updatedField  = 'updated_at';
+    protected $deletedField  = 'deleted_at';
+
+    // Validation
+    protected $validationRules      = [];
+    protected $validationMessages   = [];
+    protected $skipValidation       = false;
+    protected $cleanValidationRules = true;
+
+    // Callbacks
+    protected $allowCallbacks = true;
+    protected $beforeInsert   = [];
+    protected $afterInsert    = [];
+    protected $beforeUpdate   = [];
+    protected $afterUpdate    = [];
+    protected $beforeFind     = [];
+    protected $afterFind      = [];
+    protected $beforeDelete   = [];
+    protected $afterDelete    = [];
+
+    protected function initialize(): void
+    {
+        $this->initRelations();
+    }
+
+    public function profile(): Relation
+    {
+        return $this->hasOne(ProfileModel::class);
+    }
+
+    public function posts(): Relation
+    {
+        return $this->hasMany(PostModel::class);
+    }
+}


### PR DESCRIPTION
**Description**
This PR changes how loaded relations are assigned to returned entities.

Closes #26

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
